### PR TITLE
feat: implements issue #34

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@treecg/versionawareldesinldp",
-    "version": "0.2.2",
+    "version": "0.3.0-alpha.0",
     "description": "Library for interacting with a (versioned) LDES in LDP",
     "main": "./dist/Index.js",
     "types": "./dist/Index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@treecg/versionawareldesinldp",
-    "version": "0.3.0-alpha.0",
+    "version": "0.3.0",
     "description": "Library for interacting with a (versioned) LDES in LDP",
     "main": "./dist/Index.js",
     "types": "./dist/Index.d.ts",

--- a/src/ldes/LDESinLDP.ts
+++ b/src/ldes/LDESinLDP.ts
@@ -1,13 +1,13 @@
-import {ILDES} from "./ILDES";
-import {Communication} from "../ldp/Communication";
-import {Logger} from "../logging/Logger";
-import {filterRelation} from "../util/LdesUtil";
-import {ILDESinLDPMetadata} from "../metadata/LDESinLDPMetadata";
-import {DataFactory, Literal, Store} from "n3";
-import {Readable} from "stream";
-import {MetadataParser} from "../metadata/MetadataParser";
-import {MetadataInitializer} from "../metadata/MetadataInitializer";
-import {isContainerIdentifier} from "../util/IdentifierUtil";
+import { ILDES } from "./ILDES";
+import { Communication } from "../ldp/Communication";
+import { Logger } from "../logging/Logger";
+import { filterRelation } from "../util/LdesUtil";
+import { ILDESinLDPMetadata } from "../metadata/LDESinLDPMetadata";
+import { DataFactory, Literal, Store } from "n3";
+import { Readable } from "stream";
+import { MetadataParser } from "../metadata/MetadataParser";
+import { MetadataInitializer } from "../metadata/MetadataInitializer";
+import { isContainerIdentifier } from "../util/IdentifierUtil";
 import {
     createContainer,
     extractMembers,
@@ -15,18 +15,18 @@ import {
     retrieveDateTimeFromInbox,
     retrieveWriteLocation
 } from "./Util";
-import {storeToString, turtleStringToStore} from "../util/Conversion";
-import {LILConfig} from "../metadata/LILConfig";
-import {LDP, TREE} from "../util/Vocabularies";
-import {GreaterThanOrEqualToRelation} from "../metadata/util/Components";
-import {Status} from "./Status";
+import { storeToString, turtleStringToStore } from "../util/Conversion";
+import { LILConfig } from "../metadata/LILConfig";
+import { LDP, TREE } from "../util/Vocabularies";
+import { GreaterThanOrEqualToRelation } from "../metadata/util/Components";
+import { Status } from "./Status";
 // @ts-ignore
 import * as WacAllow from 'wac-allow';
-import {extractDateFromLiteral} from "../util/TimestampUtil";
-import {patchSparqlUpdateDelete, patchSparqlUpdateInsert} from "../util/PatchUtil";
-import {quad} from "@rdfjs/data-model";
-import {Member} from "@treecg/types";
-import {extractDateFromMember} from "../util/MemberUtil";
+import { extractDateFromLiteral } from "../util/TimestampUtil";
+import { patchSparqlUpdateDelete, patchSparqlUpdateInsert } from "../util/PatchUtil";
+import { quad } from "@rdfjs/data-model";
+import { Member } from "@treecg/types";
+import { extractDateFromMember } from "../util/MemberUtil";
 import namedNode = DataFactory.namedNode;
 
 /***************************************
@@ -95,7 +95,7 @@ export class LDESinLDP implements ILDES {
         }
         status.valid = true
 
-        const {user} = WacAllow.parse(foundResponse)
+        const { user } = WacAllow.parse(foundResponse)
         status.writable = user.has('write')
 
         if (metadata.view.relations.length === 1) {
@@ -246,7 +246,7 @@ export class LDESinLDP implements ILDES {
         })
 
         for (const relation of relations) {
-            const resources = comm.readPage(relation.node,{from, until})
+            const resources = comm.readPage(relation.node, { from, until })
             for await (const resource of resources) {
                 // member ID is based on tree:path
                 let memberId = resource.getSubjects(relation.path, null, null)[0].value
@@ -289,7 +289,7 @@ export class LDESinLDP implements ILDES {
         })
 
         for (const relation of relations) {
-            const resources = comm.readPage(relation.node,{from, until})
+            const resources = comm.readPage(relation.node, { from, until })
             const members: Member[] = []
             for await (const resource of resources) {
                 // member ID is based on tree:path
@@ -357,7 +357,7 @@ export class LDESinLDP implements ILDES {
             const store = await this.read(containerURL)
             const pageMetadata = await this.pageMedata(containerURL, store)
             let children: string[] = []
-
+            
             if (opts?.from && opts?.until && pageMetadata) {
                 // https://github.com/woutslabbinck/VersionAwareLDESinLDP/issues/34
                 children = filterRelation(pageMetadata, opts.from, opts.until).map(relation => relation.node)

--- a/src/ldes/LDESinLDP.ts
+++ b/src/ldes/LDESinLDP.ts
@@ -246,7 +246,7 @@ export class LDESinLDP implements ILDES {
         })
 
         for (const relation of relations) {
-            const resources = comm.readPage(relation.node)
+            const resources = comm.readPage(relation.node,{from, until})
             for await (const resource of resources) {
                 // member ID is based on tree:path
                 let memberId = resource.getSubjects(relation.path, null, null)[0].value
@@ -289,7 +289,7 @@ export class LDESinLDP implements ILDES {
         })
 
         for (const relation of relations) {
-            const resources = comm.readPage(relation.node)
+            const resources = comm.readPage(relation.node,{from, until})
             const members: Member[] = []
             for await (const resource of resources) {
                 // member ID is based on tree:path
@@ -352,7 +352,6 @@ export class LDESinLDP implements ILDES {
     public async* readPage(containerURL: string, opts?: {
         from?: Date;
         until?: Date;
-        chronological?: boolean
     }): AsyncIterable<Store> {
         if (isContainerIdentifier(containerURL)) {
             const store = await this.read(containerURL)

--- a/src/metadata/util/Components.ts
+++ b/src/metadata/util/Components.ts
@@ -39,6 +39,10 @@ export class Node implements INode {
         return this._id;
     }
 
+    set relations(relations: IRelation[]) {
+        this._relations = relations
+    }
+
     get relations(): IRelation[] {
         return this._relations;
     }


### PR DESCRIPTION
@argahsuknesib This PR implements issue #34.

I've implemented both:
* [`appendRelationToPage` ](https://github.com/woutslabbinck/VersionAwareLDESinLDP/blob/a7ba16d10867e22f6eea75fdc1a4db0452d252e1/src/ldes/Util.ts#L213)a util method to easily add TREE relation metadata to a container
* an extension to [`readPage`](https://github.com/woutslabbinck/VersionAwareLDESinLDP/blob/feat/containerMetadata/src/ldes/LDESinLDP.ts#L352) such that `readAllMembers` can now selectively fetch resource (based on the metadata that above implementation provides)

Following code fragment provides an example on how to use this extension
```typescript
import {
    appendRelationToPage,
    extractLdesMetadata,
    LDESinLDP,
    LDPCommunication,
    MetadataInitializer,
    MetadataParser,
    VersionAwareLDESinLDP,
    turtleStringToStore
} from "./src/Index"; // should be `@treecg/versionawareldesinldp` when published
import {Member, TREE} from "@treecg/types";

async function main() {
    const treePath = "https://saref.etsi.org/core/hasTimestamp"
    const ldes_url: string = 'http://localhost:3000/dataset_participant1/data/';
    const start = new Date()

    const communication = new LDPCommunication();
    const ldes_in_ldp = new LDESinLDP(ldes_url, communication);

    await ldes_in_ldp.initialise({treePath: treePath, date: start})

    const metadata = await ldes_in_ldp.readMetadata();
    let end = new Date()

    // add 10 members to the ldes in ldp
    let index = 0;
    const amount = 10;
    const containerNode = MetadataParser.extractLDESinLDPMetadata(metadata).view.relations[0].node
    const parsedMetadata = MetadataInitializer.generateLDESinLDPMetadata(ldes_url, {
        lilConfig: {
            treePath: treePath
        }
    })
    while (index < amount) {
        index++
        const date = new Date()
        // append data element
        const store = await turtleStringToStore(`
<${ldes_in_ldp.eventStreamIdentifier}> <${TREE.member}> <https://dahcc.idlab.ugent.be/Protego/_participant1/obs0> .
<https://dahcc.idlab.ugent.be/Protego/_participant1/obs0> <http://rdfs.org/ns/void#inDataset> <https://dahcc.idlab.ugent.be/Protego/_participant1> .
<https://dahcc.idlab.ugent.be/Protego/_participant1/obs0> <https://saref.etsi.org/core/measurementMadeBy> <https://dahcc.idlab.ugent.be/Homelab/SensorsAndActuators/70:ee:50:67:30:b2> .
<https://dahcc.idlab.ugent.be/Protego/_participant1/obs0> <https://saref.etsi.org/core/relatesToProperty> <https://dahcc.idlab.ugent.be/Homelab/SensorsAndActuators/org.dyamand.types.common.AtmosphericPressure> .
<https://dahcc.idlab.ugent.be/Protego/_participant1/obs0> <https://saref.etsi.org/core/hasTimestamp> "${date.toISOString()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<https://dahcc.idlab.ugent.be/Protego/_participant1/obs0> <https://saref.etsi.org/core/hasValue> "1013.1"^^<http://www.w3.org/2001/XMLSchema#float> .
        `)
        const location = await ldes_in_ldp.append(store) // location of the created ldp resource

        // creating relation to resource
        await appendRelationToPage({
            communication: communication, containerURL: containerNode, date: date, metadata: parsedMetadata, resourceURL: location
        })
        end = date
    }

    const memberStream = await ldes_in_ldp.readAllMembers(start, end)
    const members: Member[] = []
    for await (const member of memberStream) {
        members.push(member)
    }
    console.log(members.length)
}

main();
```

Can you test this code and check whether this satisfies your requirements? 
If they do, I'll add tests, merge this branch and publish it to npm.